### PR TITLE
Make extension configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,22 @@
 Jupyter notebook extension that periodically asks a service for a token and
 stores it in an environment variable.
 
-
 ## Install
 
 Clone this repository and then:
+
 ```
 pip install -e.
 jupyter serverextension enable --py jhoauthrefresh
+```
+
+## Configuration
+
+This extension is configured by customizing your jupyter_notebook_config.py file:
+
+```
+c.JHOauthRefreshConfig.jupyterhub_token_env_var = 'JUPYTERHUB_API_TOKEN'
+c.JHOauthRefreshConfig.oauth_token_env_var = 'OAUTH_ACCESS_TOKEN'
+c.JHOauthRefreshConfig.new_token_url = 'https://notebooks.openhumans.org/services/refresher/tokens'
+c.JHOauthRefreshConfig.renew_period = 1
 ```

--- a/README.md
+++ b/README.md
@@ -1,11 +1,18 @@
 # JupyterHub OAuth2 Token Refresher
 
-Jupyter notebook extension that periodically asks a service for a token and
+Jupyter notebook extension that periodically asks a [service](https://github.com/wildtreetech/ohjh/tree/master/images/refresher) for a token and
 stores it in an environment variable.
 
 ## Install
 
 Clone this repository and then:
+
+```
+pip install jhoauthrefresh
+jupyter serverextension enable --py jhoauthrefresh
+```
+
+### Development install
 
 ```
 pip install -e.
@@ -20,5 +27,10 @@ This extension is configured by customizing your jupyter_notebook_config.py file
 c.JHOauthRefreshConfig.jupyterhub_token_env_var = 'JUPYTERHUB_API_TOKEN'
 c.JHOauthRefreshConfig.oauth_token_env_var = 'OAUTH_ACCESS_TOKEN'
 c.JHOauthRefreshConfig.new_token_url = 'https://notebooks.openhumans.org/services/refresher/tokens'
-c.JHOauthRefreshConfig.renew_period = 1
+c.JHOauthRefreshConfig.renew_period = 5000
+```
+
+Alternatively, parameters can be passed as command line arguments to Jupyter, as such:
+```
+jupyter lab --JHOauthRefreshConfig.oauth_token_env_var='JUPYTERHUB_API_TOKEN' --JHOauthRefreshConfig.renew_period=5000
 ```

--- a/jhoauthrefresh/config.py
+++ b/jhoauthrefresh/config.py
@@ -1,0 +1,39 @@
+from traitlets import Unicode, Integer
+from traitlets.config import Configurable
+
+
+class JHOauthRefreshConfig(Configurable):
+    """
+    A Configurable that declares the configuration options
+    for the jhoauthrefresh.
+    """
+
+    jupyterhub_token_env_var = Unicode(
+        "JUPYTERHUB_API_TOKEN",
+        config=True,
+        help="Name of the environment variable storing JuyterHub API token.",
+    )
+    oauth_token_env_var = Unicode(
+        "OAUTH_ACCESS_TOKEN",
+        config=True,
+        help="Name of the environment variable storing refreshing OAuth token.",
+    )
+    new_token_url = Unicode(
+        "https://notebooks.openhumans.org/services/refresher/tokens",
+        config=True,
+        help="URL of the JupyterHub service providing refreshed token.",
+    )
+    # renew_period sets the period properly based on expiry time of the token
+    # the period has to be specified in milliseconds
+    # for example, for tokens that expire after ten hours, you can set
+    # the variable to 1e3 * 60 * 60 * 8.5 (8.5 hours)
+    renew_period = Integer(
+        default_value=3600000,
+        config=True,
+        help="Time between token refreshes in milliseconds.",
+    )
+    extension_endpoint = Unicode(
+        "oauth-token",
+        config=True,
+        help="Jupyter Server extension endpoint.",
+    )

--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,9 @@ import setuptools
 
 setuptools.setup(
     name="jhoauthrefresh",
-    version='0.2.0',
-    url="https://github.com/OpenHumans/jhoauth-refresh",
+    version="0.3.0",
+    url="https://github.com/ktaletsk/jhoauth-refresh",
     author="Tim Head",
     packages=setuptools.find_packages(),
-    install_requires=[
-        'notebook',
-    ],
+    install_requires=["notebook",],
 )

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import setuptools
 setuptools.setup(
     name="jhoauthrefresh",
     version="0.3.0",
-    url="https://github.com/ktaletsk/jhoauth-refresh",
+    url="https://github.com/OpenHumans/jhoauth-refresh",
     author="Tim Head",
     packages=setuptools.find_packages(),
     install_requires=["notebook",],


### PR DESCRIPTION
This PR:
- Makes extension configurable with the following parameters:
  - `jupyterhub_token_env_var`
  - `oauth_token_env_var`
  - `new_token_url`
  - `renew_period`
  which allows using extension with other deployments other than OpenHumans
- Migrates to Jupyter Server (`nbapp` -> `serverapp`)

I also uploaded this version on [PyPI](https://pypi.org/project/jhoauthrefresh/), since I wanted to install it in my container. Please, let me know if I can add/transfer ownersip to your org.